### PR TITLE
fix: `Match` object has no field `history_level`

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     )
     main.match.set_deck([deck, deck])
     main.match.config.max_same_card_number = 30
-    main.match.config.history_level = True
+    main.match.config.history_level = 10
     main.match.config.check_deck_restriction = False
     main.match.config.initial_hand_size = 20
     main.match.config.max_hand_size = 30

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     )
     main.match.set_deck([deck, deck])
     main.match.config.max_same_card_number = 30
-    main.match.history_level = True
+    main.match.config.history_level = True
     main.match.config.check_deck_restriction = False
     main.match.config.initial_hand_size = 20
     main.match.config.max_hand_size = 30


### PR DESCRIPTION
When I ran `python main.py`, an error occurred:

```
ValueError: "Match" object has no field "history_level"
```

It seems to be a typo, because `MatchConfig` object do have the field `history_level`.