### PR TITLE
Remove the import prefix `src.` from tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to LPSim
+
+## Prerequisites
+
+`lpsim` is written in Python, requires Python >= 3.10 to run.
+
+You'll need to install Python for development and install `pre-commit` to run validations.
+
+```sh
+pipx install pre-commit
+
+pre-commit install
+```
+
+## Development
+
+You'll need to install an editable version of `lpsim` to develop this project:
+
+```sh
+pip install -e ".[dev]"
+```
+
+This helps you install `setuptools_scm` and `pytest`.

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,22 +12,24 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
   
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -e .
         pip install -r requirements.txt
 
     - name: Run tests with coverage
       run: |
         python -m setuptools_scm
-        python -m pytest --cov
+        pytest --cov
         coverage xml
 
     - name: Upload coverage to Coveralls

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run tests with coverage
       run: |
         python -m setuptools_scm
-        pytest --cov
+        python -m pytest --cov
         coverage xml
 
     - name: Upload coverage to Coveralls

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,16 +15,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
   
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r requirements.txt
+        pip install -e ".[dev]"
 
     - name: Run tests with coverage
       run: |

--- a/README.en.md
+++ b/README.en.md
@@ -4,6 +4,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/LPSim/backend/badge.svg?branch=master)](https://coveralls.io/github/LPSim/backend?branch=master)
 [![PyPI version](https://img.shields.io/pypi/v/lpsim.svg?color=blue)](https://pypi.org/project/lpsim/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Backend of Lochfolk Prinzessin Simulator, which simulates Genius Invokation 
 TCG, written with Python 3.10 using Pydantic and FastAPI. This project has

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/LPSim/backend/badge.svg?branch=master)](https://coveralls.io/github/LPSim/backend?branch=master)
 [![PyPI version](https://img.shields.io/pypi/v/lpsim.svg?color=blue)](https://pypi.org/project/lpsim/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 ### [**English README**](README.en.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lpsim"
 dynamic = ["version"]
-authors = [
-    { name="Zyr17", email="jzjqz17@gmail.com" },
-]
+authors = [{ name = "Zyr17", email = "jzjqz17@gmail.com" }]
 description = "Lochfolk Prinzessin Simulator, which simulates Genius Invokation TCG"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -23,8 +21,11 @@ dependencies = [
     "typing_extensions",
     "dictdiffer",
     "fastapi",
-    "uvicorn[standard]"
+    "uvicorn[standard]",
 ]
+
+[project.optional-dependencies]
+dev = ["setuptools-scm", "pytest", "pytest-cov", "pytest-xdist"]
 
 [project.urls]
 "Homepage" = "https://github.com/LPSim/backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["setuptools-scm", "pytest<8.0.0", "pytest-cov", "pytest-xdist"]
+dev = ["setuptools-scm", "pytest", "pytest-cov", "pytest-xdist"]
 
 [project.urls]
 "Homepage" = "https://github.com/LPSim/backend"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["setuptools-scm", "pytest", "pytest-cov", "pytest-xdist"]
+dev = ["setuptools-scm", "pytest<8.0.0", "pytest-cov", "pytest-xdist"]
 
 [project.urls]
 "Homepage" = "https://github.com/LPSim/backend"

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ filterwarnings =
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
 
 # Build in coverage and pytest-xdist multiproc testing.
-addopts = --cov --durations=30 -n auto --dist worksteal
+addopts = --cov --durations=30 -n auto --dist worksteal --import-mode=importlib
 
 # Our pytest units are located in the ./test/ directory.
 testpaths = tests

--- a/tests/server/bugfix/template.py
+++ b/tests/server/bugfix/template.py
@@ -1,6 +1,6 @@
 import json
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/bugfix/test_boar_talent.py
+++ b/tests/server/bugfix/test_boar_talent.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     get_test_id_from_command,
     make_respond,

--- a/tests/server/bugfix/test_counter_reset_when_revive.py
+++ b/tests/server/bugfix/test_counter_reset_when_revive.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/bugfix/test_dunyarzad_no_draw.py
+++ b/tests/server/bugfix/test_dunyarzad_no_draw.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     get_test_id_from_command,
     make_respond,

--- a/tests/server/bugfix/test_dvalin_talent.py
+++ b/tests/server/bugfix/test_dvalin_talent.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/bugfix/test_dvalin_talent_2.py
+++ b/tests/server/bugfix/test_dvalin_talent_2.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/bugfix/test_kazuha_attack_by_baizhu_q.py
+++ b/tests/server/bugfix/test_kazuha_attack_by_baizhu_q.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     get_test_id_from_command,

--- a/tests/server/bugfix/test_nilou_dendro_core.py
+++ b/tests/server/bugfix/test_nilou_dendro_core.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/bugfix/test_trigger_order_in_character.py
+++ b/tests/server/bugfix/test_trigger_order_in_character.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     get_test_id_from_command,

--- a/tests/server/cards/test_arcane_legend.py
+++ b/tests/server/cards/test_arcane_legend.py
@@ -1,6 +1,6 @@
-from src.lpsim.server.deck import Deck
-from src.lpsim.server.interaction import UseCardResponse
-from src.lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
+from lpsim.server.interaction import UseCardResponse
+from lpsim.server.match import Match, MatchState
 
 from tests.utils_for_test import (
     check_hp,
@@ -9,8 +9,8 @@ from tests.utils_for_test import (
     make_respond,
     set_16_omni,
 )
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
 
 
 def test_covenant_of_rock():

--- a/tests/server/cards/test_artifacts.py
+++ b/tests/server/cards/test_artifacts.py
@@ -1,7 +1,7 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent_V1_0, InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent_V1_0, InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_pidx_cidx,
@@ -10,7 +10,7 @@ from tests.utils_for_test import (
     get_random_state,
     set_16_omni,
 )
-from src.lpsim.server.interaction import UseSkillRequest
+from lpsim.server.interaction import UseSkillRequest
 
 
 def test_small_elemental_artifacts():

--- a/tests/server/cards/test_element_resonance.py
+++ b/tests/server/cards/test_element_resonance.py
@@ -1,7 +1,7 @@
-from src.lpsim.server.struct import ObjectPosition
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.server.struct import ObjectPosition
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/cards/test_event_cards.py
+++ b/tests/server/cards/test_event_cards.py
@@ -1,7 +1,7 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/cards/test_food.py
+++ b/tests/server/cards/test_food.py
@@ -1,7 +1,7 @@
-from src.lpsim.server.struct import ObjectPosition
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.server.struct import ObjectPosition
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/cards/test_nation_resonance.py
+++ b/tests/server/cards/test_nation_resonance.py
@@ -1,7 +1,7 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.deck import Deck
-from src.lpsim.server.match import Match, MatchState
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.deck import Deck
+from lpsim.server.match import Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/cards/test_vermillion_shimenawa.py
+++ b/tests/server/cards/test_vermillion_shimenawa.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/cards/test_weapons.py
+++ b/tests/server/cards/test_weapons.py
@@ -1,7 +1,7 @@
-from src.lpsim.server.struct import ObjectPosition
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.server.struct import ObjectPosition
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/anemo/test_jean.py
+++ b/tests/server/characters/anemo/test_jean.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/anemo/test_kaedehara_kazuha.py
+++ b/tests/server/characters/anemo/test_kaedehara_kazuha.py
@@ -1,7 +1,7 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.consts import DamageElementalType
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.consts import DamageElementalType
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/anemo/test_maguu_kenki.py
+++ b/tests/server/characters/anemo/test_maguu_kenki.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/anemo/test_sucrose.py
+++ b/tests/server/characters/anemo/test_sucrose.py
@@ -1,7 +1,7 @@
-from src.lpsim.server.character.anemo.sucrose_3_3 import LargeWindSpirit_3_3
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
-from src.lpsim.server.consts import DamageElementalType
+from lpsim.server.character.anemo.sucrose_3_3 import LargeWindSpirit_3_3
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
+from lpsim.server.consts import DamageElementalType
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/anemo/test_venti.py
+++ b/tests/server/characters/anemo/test_venti.py
@@ -1,7 +1,7 @@
-from src.lpsim.server.character.anemo.venti_3_7 import Stormeye_3_7
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.server.character.anemo.venti_3_7 import Stormeye_3_7
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/anemo/test_wanderer.py
+++ b/tests/server/characters/anemo/test_wanderer.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/anemo/test_xiao.py
+++ b/tests/server/characters/anemo/test_xiao.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_ayaka.py
+++ b/tests/server/characters/cryo/test_ayaka.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_chongyun.py
+++ b/tests/server/characters/cryo/test_chongyun.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_diona.py
+++ b/tests/server/characters/cryo/test_diona.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_eula.py
+++ b/tests/server/characters/cryo/test_eula.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_ganyu.py
+++ b/tests/server/characters/cryo/test_ganyu.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_kaeya.py
+++ b/tests/server/characters/cryo/test_kaeya.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_qiqi.py
+++ b/tests/server/characters/cryo/test_qiqi.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/cryo/test_shenhe.py
+++ b/tests/server/characters/cryo/test_shenhe.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/dendro/test_baizhu.py
+++ b/tests/server/characters/dendro/test_baizhu.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/dendro/test_collei.py
+++ b/tests/server/characters/dendro/test_collei.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/dendro/test_grass_chicken.py
+++ b/tests/server/characters/dendro/test_grass_chicken.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/dendro/test_nahida.py
+++ b/tests/server/characters/dendro/test_nahida.py
@@ -1,8 +1,8 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.consts import DamageElementalType
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.consts import DamageElementalType
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_test_id_from_command,

--- a/tests/server/characters/dendro/test_tighnari.py
+++ b/tests/server/characters/dendro/test_tighnari.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/dendro/test_yaoyao.py
+++ b/tests/server/characters/dendro/test_yaoyao.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/electro/test_beidou.py
+++ b/tests/server/characters/electro/test_beidou.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_pidx_cidx,

--- a/tests/server/characters/electro/test_cyno.py
+++ b/tests/server/characters/electro/test_cyno.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/electro/test_dori.py
+++ b/tests/server/characters/electro/test_dori.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_pidx_cidx,

--- a/tests/server/characters/electro/test_electro_hypostasis.py
+++ b/tests/server/characters/electro/test_electro_hypostasis.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/electro/test_fischl.py
+++ b/tests/server/characters/electro/test_fischl.py
@@ -1,7 +1,7 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import check_hp, make_respond, get_random_state
 
 

--- a/tests/server/characters/electro/test_keqing.py
+++ b/tests/server/characters/electro/test_keqing.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/electro/test_kujou_sara.py
+++ b/tests/server/characters/electro/test_kujou_sara.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/electro/test_lisa.py
+++ b/tests/server/characters/electro/test_lisa.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/electro/test_miko.py
+++ b/tests/server/characters/electro/test_miko.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/electro/test_raiden_shogun.py
+++ b/tests/server/characters/electro/test_raiden_shogun.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/electro/test_razor.py
+++ b/tests/server/characters/electro/test_razor.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_pidx_cidx,

--- a/tests/server/characters/geo/test_albedo.py
+++ b/tests/server/characters/geo/test_albedo.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/geo/test_arataki_itto.py
+++ b/tests/server/characters/geo/test_arataki_itto.py
@@ -1,7 +1,7 @@
-from src.lpsim.server.status.character_status.geo_characters import RagingOniKing_3_6
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.server.status.character_status.geo_characters import RagingOniKing_3_6
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/geo/test_ningguang.py
+++ b/tests/server/characters/geo/test_ningguang.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/geo/test_noelle.py
+++ b/tests/server/characters/geo/test_noelle.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/geo/test_stonehide.py
+++ b/tests/server/characters/geo/test_stonehide.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/geo/test_zhongli.py
+++ b/tests/server/characters/geo/test_zhongli.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/hydro/test_barbara.py
+++ b/tests/server/characters/hydro/test_barbara.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_name,

--- a/tests/server/characters/hydro/test_candace.py
+++ b/tests/server/characters/hydro/test_candace.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/hydro/test_kamisato_ayato_and_cryo_cicin.py
+++ b/tests/server/characters/hydro/test_kamisato_ayato_and_cryo_cicin.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/hydro/test_kokomi.py
+++ b/tests/server/characters/hydro/test_kokomi.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/hydro/test_mirror_maiden.py
+++ b/tests/server/characters/hydro/test_mirror_maiden.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/hydro/test_mona.py
+++ b/tests/server/characters/hydro/test_mona.py
@@ -1,7 +1,7 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_test_id_from_command,

--- a/tests/server/characters/hydro/test_nilou.py
+++ b/tests/server/characters/hydro/test_nilou.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/hydro/test_rhodeia.py
+++ b/tests/server/characters/hydro/test_rhodeia.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/hydro/test_tartaglia.py
+++ b/tests/server/characters/hydro/test_tartaglia.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/hydro/test_xingqiu.py
+++ b/tests/server/characters/hydro/test_xingqiu.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/pyro/test_abyss_fire.py
+++ b/tests/server/characters/pyro/test_abyss_fire.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/pyro/test_amber.py
+++ b/tests/server/characters/pyro/test_amber.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/pyro/test_bennett.py
+++ b/tests/server/characters/pyro/test_bennett.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/pyro/test_dead_agent.py
+++ b/tests/server/characters/pyro/test_dead_agent.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_usage,
@@ -88,9 +88,9 @@ def test_dead_agent():
     for table in match.player_tables:
         character = table.characters[1]
         assert character.name == "Fatui Pyro Agent"
-        from src.lpsim.server.character.pyro.fatui_pyro_agent_3_3 import PaidinFull_3_3
-        from src.lpsim.server.consts import ObjectPositionType
-        from src.lpsim.server.struct import ObjectPosition
+        from lpsim.server.character.pyro.fatui_pyro_agent_3_3 import PaidinFull_3_3
+        from lpsim.server.consts import ObjectPositionType
+        from lpsim.server.struct import ObjectPosition
 
         talent = PaidinFull_3_3(name="Paid in Full")
         talent.position = ObjectPosition(

--- a/tests/server/characters/pyro/test_dehya.py
+++ b/tests/server/characters/pyro/test_dehya.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/characters/pyro/test_diluc.py
+++ b/tests/server/characters/pyro/test_diluc.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim import Match, MatchState, Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim import Match, MatchState, Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/pyro/test_hutao.py
+++ b/tests/server/characters/pyro/test_hutao.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/pyro/test_klee.py
+++ b/tests/server/characters/pyro/test_klee.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/pyro/test_xiangling.py
+++ b/tests/server/characters/pyro/test_xiangling.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/pyro/test_yanfei.py
+++ b/tests/server/characters/pyro/test_yanfei.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/pyro/test_yoimiya.py
+++ b/tests/server/characters/pyro/test_yoimiya.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/characters/test_mobs.py
+++ b/tests/server/characters/test_mobs.py
@@ -1,5 +1,5 @@
 import pytest
-from src.lpsim.server.deck import Deck
+from lpsim.server.deck import Deck
 
 
 def test_create_mob():

--- a/tests/server/patch/v43/test_alhaitham.py
+++ b/tests/server/patch/v43/test_alhaitham.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_azhdaha.py
+++ b/tests/server/patch/v43/test_azhdaha.py
@@ -1,10 +1,10 @@
 import os
 
-from src.lpsim.server.deck import Deck
+from lpsim.server.deck import Deck
 
-from src.lpsim.server.match import Match
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim import MatchState
+from lpsim.server.match import Match
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_dvalin.py
+++ b/tests/server/patch/v43/test_dvalin.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_eremite.py
+++ b/tests/server/patch/v43/test_eremite.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_usage,
     get_test_id_from_command,

--- a/tests/server/patch/v43/test_fishchip_gilded.py
+++ b/tests/server/patch/v43/test_fishchip_gilded.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     get_random_state,
     get_test_id_from_command,

--- a/tests/server/patch/v43/test_four_leaf.py
+++ b/tests/server/patch/v43/test_four_leaf.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     get_random_state,
     get_test_id_from_command,

--- a/tests/server/patch/v43/test_gorou.py
+++ b/tests/server/patch/v43/test_gorou.py
@@ -1,7 +1,7 @@
 # TODO: only one geo with burst
 
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_layla_yelan.py
+++ b/tests/server/patch/v43/test_layla_yelan.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_lynette.py
+++ b/tests/server/patch/v43/test_lynette.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_lyney.py
+++ b/tests/server/patch/v43/test_lyney.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_mamere_judgment.py
+++ b/tests/server/patch/v43/test_mamere_judgment.py
@@ -1,7 +1,7 @@
 import json
 from typing import Dict
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_memento_lens.py
+++ b/tests/server/patch/v43/test_memento_lens.py
@@ -1,6 +1,6 @@
 import json
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import get_random_state, make_respond, remove_ids, set_16_omni
 
 

--- a/tests/server/patch/v43/test_new_4_transform.py
+++ b/tests/server/patch/v43/test_new_4_transform.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     get_pidx_cidx,
     get_test_id_from_command,

--- a/tests/server/patch/v43/test_opera_weeping.py
+++ b/tests/server/patch/v43/test_opera_weeping.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_usage,
     get_random_state,

--- a/tests/server/patch/v43/test_others_v43.py
+++ b/tests/server/patch/v43/test_others_v43.py
@@ -1,7 +1,7 @@
 # tests that test corner cases to improve coverage
 
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_rhodeia_ocean_stone_v43.py
+++ b/tests/server/patch/v43/test_rhodeia_ocean_stone_v43.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_seed_dispensary.py
+++ b/tests/server/patch/v43/test_seed_dispensary.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     get_test_id_from_command,
     make_respond,

--- a/tests/server/patch/v43/test_signora.py
+++ b/tests/server/patch/v43/test_signora.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_thunder_manifestation.py
+++ b/tests/server/patch/v43/test_thunder_manifestation.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/patch/v43/test_timaeus_wagner_v43.py
+++ b/tests/server/patch/v43/test_timaeus_wagner_v43.py
@@ -1,5 +1,5 @@
 import os
-from src.lpsim import MatchState
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_usage,
     get_test_id_from_command,

--- a/tests/server/patch/v43/test_v43equips_boar_fall.py
+++ b/tests/server/patch/v43/test_v43equips_boar_fall.py
@@ -1,9 +1,9 @@
 import os
 
-from src.lpsim.server.deck import Deck
-from src.lpsim.server.match import Match
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim import MatchState
+from lpsim.server.deck import Deck
+from lpsim.server.match import Match
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim import MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/scenario/test_maguu_kenki_10_10_10.py
+++ b/tests/server/scenario/test_maguu_kenki_10_10_10.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/scenario/test_wanderer_icyquill.py
+++ b/tests/server/scenario/test_wanderer_icyquill.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/supports/test_companions.py
+++ b/tests/server/supports/test_companions.py
@@ -1,9 +1,9 @@
 import json
 from typing import Dict
-from src.lpsim.agents.interaction_agent import InteractionAgent_V1_0, InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent_V1_0, InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_usage,
     get_pidx_cidx,

--- a/tests/server/supports/test_items.py
+++ b/tests/server/supports/test_items.py
@@ -1,6 +1,6 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_usage,
     get_random_state,

--- a/tests/server/supports/test_locations.py
+++ b/tests/server/supports/test_locations.py
@@ -1,12 +1,12 @@
 from typing import Any, List
-from src.lpsim.server.event import RoundEndEventArguments
-from src.lpsim.server.struct import ObjectPosition
-from src.lpsim.server.consts import DieColor, ObjectPositionType
-from src.lpsim.server.card.support.companions import Liben_3_3
-from src.lpsim.server.card.support.locations import Vanarana_3_7
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
+from lpsim.server.event import RoundEndEventArguments
+from lpsim.server.struct import ObjectPosition
+from lpsim.server.consts import DieColor, ObjectPositionType
+from lpsim.server.card.support.companions import Liben_3_3
+from lpsim.server.card.support.locations import Vanarana_3_7
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/test_deck.py
+++ b/tests/server/test_deck.py
@@ -1,4 +1,4 @@
-from src.lpsim.server.deck import Deck
+from lpsim.server.deck import Deck
 from tests.utils_for_test import remove_ids
 
 

--- a/tests/server/test_deck_code.py
+++ b/tests/server/test_deck_code.py
@@ -1,6 +1,6 @@
 import pytest
-from src.lpsim.utils import deck_code_to_deck_str, deck_str_to_deck_code
-from src.lpsim import Deck
+from lpsim.utils import deck_code_to_deck_str, deck_str_to_deck_code
+from lpsim import Deck
 
 
 def test_deck_code():

--- a/tests/server/test_draw_card.py
+++ b/tests/server/test_draw_card.py
@@ -1,9 +1,9 @@
-from src.lpsim.server.interaction import SwitchCardResponse
+from lpsim.server.interaction import SwitchCardResponse
 from tests.utils_for_test import make_respond
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.match import Match
-from src.lpsim.server.deck import Deck
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.match import Match
+from lpsim.server.deck import Deck
 
 
 def test_draw_card():

--- a/tests/server/test_elemental_reaction.py
+++ b/tests/server/test_elemental_reaction.py
@@ -1,9 +1,9 @@
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.elemental_reaction import check_elemental_reaction
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
-from src.lpsim.server.consts import (
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.elemental_reaction import check_elemental_reaction
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
+from lpsim.server.consts import (
     DamageElementalType,
     ElementType,
     ElementalReactionType,

--- a/tests/server/test_interaction.py
+++ b/tests/server/test_interaction.py
@@ -1,6 +1,6 @@
-from src.lpsim.server.consts import DieColor, ObjectPositionType
-from src.lpsim.server.deck import Deck
-from src.lpsim.server.interaction import (
+from lpsim.server.consts import DieColor, ObjectPositionType
+from lpsim.server.deck import Deck
+from lpsim.server.interaction import (
     SwitchCardRequest,
     SwitchCardResponse,
     RerollDiceRequest,
@@ -12,8 +12,8 @@ from src.lpsim.server.interaction import (
     UseSkillRequest,
     UseSkillResponse,
 )
-from src.lpsim.server.match import Match
-from src.lpsim.server.struct import Cost, ObjectPosition
+from lpsim.server.match import Match
+from lpsim.server.struct import Cost, ObjectPosition
 
 
 def test_response_is_valid():

--- a/tests/server/test_others.py
+++ b/tests/server/test_others.py
@@ -1,22 +1,22 @@
 from typing import Dict, Literal
 import pytest
-from src.lpsim.utils.desc_registry import DescDictType
+from lpsim.utils.desc_registry import DescDictType
 
-from src.lpsim.server.status.team_status.base import (
+from lpsim.server.status.team_status.base import (
     ElementalInfusionTeamStatus,
     TeamStatusBase,
 )
-from src.lpsim.utils.class_registry import get_instance, register_class
+from lpsim.utils.class_registry import get_instance, register_class
 
-from src.lpsim.agents.random_agent import RandomAgent
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.action import CreateDiceAction, DrawCardAction, MoveObjectAction
-from src.lpsim.server.consts import DamageElementalType, ObjectPositionType
-from src.lpsim.server.deck import Deck
-from src.lpsim.server.interaction import SwitchCardResponse
-from src.lpsim.server.object_base import ObjectBase
-from src.lpsim.server.struct import ObjectPosition
-from src.lpsim.server.match import Match, MatchConfig
+from lpsim.agents.random_agent import RandomAgent
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.action import CreateDiceAction, DrawCardAction, MoveObjectAction
+from lpsim.server.consts import DamageElementalType, ObjectPositionType
+from lpsim.server.deck import Deck
+from lpsim.server.interaction import SwitchCardResponse
+from lpsim.server.object_base import ObjectBase
+from lpsim.server.struct import ObjectPosition
+from lpsim.server.match import Match, MatchConfig
 
 
 def test_object_position_validation():

--- a/tests/server/test_pipeline.py
+++ b/tests/server/test_pipeline.py
@@ -4,19 +4,19 @@ from typing import Literal
 import dictdiffer
 import pytest
 
-from src.lpsim.server.struct import Cost, ObjectPosition
-from src.lpsim.server.event import UseCardEventArguments
-from src.lpsim.server.action import ActionTypes, UseCardAction
-from src.lpsim.utils.class_registry import get_instance
-from src.lpsim.server.summon.base import SummonBase
-from src.lpsim.server.consts import ObjectPositionType, ObjectType
-from src.lpsim.agents.nothing_agent import NothingAgent
-from src.lpsim.server.event_handler import OmnipotentGuideEventHandler_3_3
-from src.lpsim.server.match import Match, MatchState
-from src.lpsim.server.deck import Deck
-from src.lpsim.agents.random_agent import RandomAgent
-from src.lpsim.agents.interaction_agent import InteractionAgent
-from src.lpsim.server.character.electro.fischl_3_3 import Oz_3_3
+from lpsim.server.struct import Cost, ObjectPosition
+from lpsim.server.event import UseCardEventArguments
+from lpsim.server.action import ActionTypes, UseCardAction
+from lpsim.utils.class_registry import get_instance
+from lpsim.server.summon.base import SummonBase
+from lpsim.server.consts import ObjectPositionType, ObjectType
+from lpsim.agents.nothing_agent import NothingAgent
+from lpsim.server.event_handler import OmnipotentGuideEventHandler_3_3
+from lpsim.server.match import Match, MatchState
+from lpsim.server.deck import Deck
+from lpsim.agents.random_agent import RandomAgent
+from lpsim.agents.interaction_agent import InteractionAgent
+from lpsim.server.character.electro.fischl_3_3 import Oz_3_3
 from tests.utils_for_test import (
     get_test_id_from_command,
     set_16_omni,

--- a/tests/server/test_recreate_mode.py
+++ b/tests/server/test_recreate_mode.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/server/test_registry.py
+++ b/tests/server/test_registry.py
@@ -1,25 +1,25 @@
 from typing import Dict, Literal
 
 import pytest
-from src.lpsim.server.card.support.companions import CompanionBase
-from src.lpsim.server.card.event.foods import FoodCardBase
-from src.lpsim.server.card.support.base import SupportBase
-from src.lpsim.server.summon.base import SummonBase
-from src.lpsim.server.character.character_base import CharacterBase
-from src.lpsim.utils.desc_registry import (
+from lpsim.server.card.support.companions import CompanionBase
+from lpsim.server.card.event.foods import FoodCardBase
+from lpsim.server.card.support.base import SupportBase
+from lpsim.server.summon.base import SummonBase
+from lpsim.server.character.character_base import CharacterBase
+from lpsim.utils.desc_registry import (
     DescDictType,
     desc_exist,
     get_desc_patch,
     update_cost,
     update_desc,
 )
-from src.lpsim.utils.class_registry import (
+from lpsim.utils.class_registry import (
     get_class_list_by_base_class,
     get_instance,
     register_class,
 )
-from src.lpsim.server.struct import Cost
-from src.lpsim.server.object_base import EventCardBase
+from lpsim.server.struct import Cost
+from lpsim.server.object_base import EventCardBase
 
 
 def test_class_registry():

--- a/tests/server/version_update/test_version_4_1.py
+++ b/tests/server/version_update/test_version_4_1.py
@@ -3,8 +3,8 @@
 This file contains a template for writing tests. You can copy this file to
 tests/folder/test_xxx.py and modify it to write your own tests.
 """
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     get_random_state,

--- a/tests/server/version_update/test_version_4_2.py
+++ b/tests/server/version_update/test_version_4_2.py
@@ -1,5 +1,5 @@
-from src.lpsim.agents import InteractionAgent
-from src.lpsim import Deck, Match, MatchState
+from lpsim.agents import InteractionAgent
+from lpsim import Deck, Match, MatchState
 from tests.utils_for_test import (
     check_hp,
     check_usage,

--- a/tests/utils_for_test.py
+++ b/tests/utils_for_test.py
@@ -1,13 +1,13 @@
 import json
 import numpy as np
 from typing import List, Any, Tuple
-from src.lpsim.agents.interaction_agent import InteractionAgent, InteractionAgent_V1_0
-from src.lpsim.server.match import Match, MatchConfig
-from src.lpsim.server.deck import Deck
-from src.lpsim.server.event_handler import OmnipotentGuideEventHandler_3_3
-from src.lpsim.agents.agent_base import AgentBase
-from src.lpsim.server.struct import ObjectPosition
-from src.lpsim.utils import BaseModel
+from lpsim.agents.interaction_agent import InteractionAgent, InteractionAgent_V1_0
+from lpsim.server.match import Match, MatchConfig
+from lpsim.server.deck import Deck
+from lpsim.server.event_handler import OmnipotentGuideEventHandler_3_3
+from lpsim.agents.agent_base import AgentBase
+from lpsim.server.struct import ObjectPosition
+from lpsim.utils import BaseModel
 from tests.default_random_state import get_default_random_state
 
 


### PR DESCRIPTION
This commit remove all import prefix `src.` from tests files. We now need to run `pip install -e .` locally to pass pytest.