### PR TITLE
chore: update vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "charliermarsh.ruff"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,5 @@
 {
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
-    },
-    "python.formatting.provider": "none",
-    "flake8.ignorePatterns": [
-        "frontend",
-        "build"
-    ]
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    }
 }


### PR DESCRIPTION
We use the `ruff` extension as the default formatter.